### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: libnetfilter-cttimeout
 Priority: extra
 Maintainer: Alexander Wirt <formorer@debian.org>
-Build-Depends: debhelper (>= 9.0.0),
+Build-Depends: debhelper (>= 9.20160114),
                libmnl-dev (>= 1.0.0),
                libtool,
                pkg-config
@@ -36,17 +36,3 @@ Description: fine-grain connection tracking timeout infrastructure for netfilter
  interface to the fine-grain connection tracking timeout infrastructure. With
  this library, you can create, update and delete timeout policies that can be
  attached to traffic flows. This library is used by conntrack-tools.
-
-Package: libnetfilter-cttimeout1-dbg
-Section: debug
-Architecture: any
-Depends: libnetfilter-cttimeout1 (=  ${binary:Version}),
-         ${misc:Depends},
-         ${shlibs:Depends}
-Description: fine-grain connection tracking timeout infrastructure for netfilter
- libnetfilter_cttimeout is the userspace library that provides the programming
- interface to the fine-grain connection tracking timeout infrastructure. With
- this library, you can create, update and delete timeout policies that can be
- attached to traffic flows. This library is used by conntrack-tools.
- .
- This package provides the debugging symbols.

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends: debhelper (>= 9.0.0),
 Standards-Version: 3.9.3
 Section: libs
 Homepage: http://www.netfilter.org/projects/libnetfilter_cttimeout
-Vcs-Git: git://github.com/formorer/pkg-libnetfilter-cttimeout.git
+Vcs-Git: https://github.com/formorer/pkg-libnetfilter-cttimeout.git
 Vcs-Browser: https://github.com/formorer/pkg-libnetfilter-cttimeout
 
 Package: libnetfilter-cttimeout-dev

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,4 +1,4 @@
-Format: http://dep.debian.net/deps/dep5
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: libnetfilter-cttimeout
 Source: http://www.netfilter.org/projects/libnetfilter_cttimeout/index.html
 

--- a/debian/rules
+++ b/debian/rules
@@ -13,7 +13,7 @@
 	dh $@ 
 
 override_dh_strip:
-	dh_strip --dbg-package=libnetfilter-cttimeout1-dbg
+	dh_strip --dbgsym-migration='libnetfilter-cttimeout1-dbg (<< 1.0.0-3~)'
 
 override_dh_installdocs:
 	dh_installdocs --link-doc=libnetfilter-cttimeout1


### PR DESCRIPTION
Fix some issues reported by lintian
* Transition to automatic debug package (from: libnetfilter-cttimeout1-dbg).
* Use versioned copyright format URI.
* Use secure URI in Vcs control header.
